### PR TITLE
Changes twitter card form large image to summary

### DIFF
--- a/code/views/home/partials/head.php
+++ b/code/views/home/partials/head.php
@@ -14,7 +14,7 @@
     <meta property="og:image" content="<?= $meta['image'] ?>">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary">
+    <meta property="twitter:card" content="<?= $_GET['q1'] ? 'summary' : 'summary_large_image' ?>">
     <meta property="twitter:url" content="<?= $meta['url'] ?>">
     <meta property="twitter:title" content="<?= $meta['title'] ?>">
     <meta property="twitter:description" content="<?= $meta['description'] ?>">

--- a/code/views/home/partials/head.php
+++ b/code/views/home/partials/head.php
@@ -14,7 +14,7 @@
     <meta property="og:image" content="<?= $meta['image'] ?>">
 
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:card" content="summary">
     <meta property="twitter:url" content="<?= $meta['url'] ?>">
     <meta property="twitter:title" content="<?= $meta['title'] ?>">
     <meta property="twitter:description" content="<?= $meta['description'] ?>">


### PR DESCRIPTION
This should create smaller embedded previews., if sharing specific plugins, users, or lists.
The current one is too obnoxious:
![image](https://user-images.githubusercontent.com/23201434/81510848-72402e00-92eb-11ea-8d2a-4de0a1caaa7b.png)

We still show the large_image if sharing the home page