### PR TITLE
Change plugin URL to releases page

### DIFF
--- a/code/features/plugin/plugin.php
+++ b/code/features/plugin/plugin.php
@@ -10,7 +10,7 @@ if (empty($plugin['id'])) {
 // set meta information
 $meta['title'] = $plugin['name'] . ' | OpenRCT2 Plug-ins Directory';
 $meta['description'] = $plugin['description'];
-$meta['url'] = $_SERVER['REQUEST_SCHEME'] . '://' . $_ENV['DOMAIN_NAME'] . '/plugin/' . $plugin['id'] . '/' . urlencode($plugin['name']);
+$meta['url'] = $_SERVER['REQUEST_SCHEME'] . '://' . $_ENV['DOMAIN_NAME'] . '/plugin/' . $plugin['id'] . '/' . urlencode($plugin['name']) . '/releases';
 if ($plugin['usesCustomOpenGraphImage'] == 1) {
     $meta['image'] = $plugin['thumbnail'];
 }


### PR DESCRIPTION
This is a proposal for making it easier for users to find the file to download.

This change will require all plugin makers to set up a release to simplify the installation process for users that are less technically inclined.