### PR TITLE
Fix for #19: Account for branches named "main"

### DIFF
--- a/code/index.php
+++ b/code/index.php
@@ -53,6 +53,6 @@ switch ($_GET['q1']) {
 // debugging
 debug($_GET, 'GET');
 // debug($_ENV, 'ENV');
-// debug($_POST, 'POST');
+debug($_POST, 'POST');
 // debug($db_status, 'DB status');
 // debug($_COOKIE, 'COOKIE');

--- a/code/index.php
+++ b/code/index.php
@@ -53,6 +53,6 @@ switch ($_GET['q1']) {
 // debugging
 debug($_GET, 'GET');
 // debug($_ENV, 'ENV');
-debug($_POST, 'POST');
+// debug($_POST, 'POST');
 // debug($db_status, 'DB status');
 // debug($_COOKIE, 'COOKIE');

--- a/code/lib/db/submit.php
+++ b/code/lib/db/submit.php
@@ -78,6 +78,26 @@ query {
           text
         }
       }
+      readme5: object(expression: "main:readme.md") {
+        ... on Blob {
+          text
+        }
+      }
+      readme6: object(expression: "main:README.md") {
+        ... on Blob {
+          text
+        }
+      }
+      readme7: object(expression: "main:readme.MD") {
+        ... on Blob {
+          text
+        }
+      }
+      readme8: object(expression: "main:README.MD") {
+        ... on Blob {
+          text
+        }
+      }
       repositoryTopics(first: 25) {
         edges {
           node {
@@ -122,6 +142,10 @@ GRAPHQL;
   $readme .= $result['data']['repository']['readme2']['text'];
   $readme .= $result['data']['repository']['readme3']['text'];
   $readme .= $result['data']['repository']['readme4']['text'];
+  $readme .= $result['data']['repository']['readme5']['text'];
+  $readme .= $result['data']['repository']['readme6']['text'];
+  $readme .= $result['data']['repository']['readme7']['text'];
+  $readme .= $result['data']['repository']['readme8']['text'];
 
   // PLUGINS db insert
   $sql = "INSERT INTO `plugins` (`id`, `name`, `url`, `description`, ";


### PR DESCRIPTION
This PR fixes issue #19 , where sometimes we can't get the plugin's readme.

This is due to GitHub changing the main branch name from "master" to "main"  by default. Since we only searched for readmes in the `master` branch, we can't find the specified file on newer repos.

This PR adds `main` to the list of branches to look for, without breaking the search in repos with `master`