### PR TITLE
fixed updated date not working

### DIFF
--- a/code/lib/db/submit.php
+++ b/code/lib/db/submit.php
@@ -58,7 +58,7 @@ query {
         avatarUrl
         url
       }
-			releases (last: 1) {
+			releases (first: 1) {
 			  edges {
 			    node {
             publishedAt


### PR DESCRIPTION
Fixed the issue where the "updated date" wouldn't show up correctly if the plugin had multiple releases