### PR TITLE
API

### DIFF
--- a/code/features/home/home.php
+++ b/code/features/home/home.php
@@ -12,5 +12,13 @@ $nav['active'] = 'home';
 $list_new = getPluginList($p, 6, 'new');
 $list_rating = getPluginList($p, 6, 'rating');
 
+// if the user requested the info as JSON
+if (isset($_GET['json'])) {
+    header('Content-Type: application/json');
+    $list = array( "new" => $list_new, "rating" => $list_rating); // merge the new and rating lists
+    $json = json_encode($list);
+    echo $json;
+    die;
+}
 // loads view
 include_once("views/home/home.php");

--- a/code/features/list/list.php
+++ b/code/features/list/list.php
@@ -4,6 +4,11 @@
 $meta['title'] = 'Newest Plug-ins | OpenRCT2 Plug-ins Directory';
 $meta['description'] = 'Get the latest plug-ins submitted to our directly of OpenRCT2 plug-ins';
 
+// number of list items per page, limited to 100
+$resultsPerPage = isset($_GET['results']) ? intval($_GET['results']) : 8;
+if ($resultsPerPage > 100) {
+    $resultsPerPage = 100;
+}
 
 if (!empty($_GET['search'])) {
 
@@ -19,31 +24,39 @@ if (!empty($_GET['search'])) {
             $meta['title'] = 'Most starred Plug-ins | OpenRCT2 Plug-ins Directory';
             $meta['description'] = 'Get the highest rated plug-ins submitted to our directory of OpenRCT2 plug-ins';
             $nav['active'] = 'rating';
-            $list = getPluginList($p, 8, 'rating');
+            $list = getPluginList($p, $resultsPerPage, 'rating');
             $list['info']['title'] = "Most starred plug-ins";
             break;
         case 'name':
             $meta['title'] = 'Plug-ins directory | OpenRCT2 Plug-ins Directory';
             $meta['description'] = 'Plug-ins submitted to our directory, in alphabetical order';
             $nav['active'] = 'name';
-            $list = getPluginList($p, 8, 'name');
+            $list = getPluginList($p, $resultsPerPage, 'name');
             $list['info']['title'] = "Plug-ins in alphabetical order";
             break;
         case 'updated':
             $meta['title'] = 'Recently updated plug-ins | OpenRCT2 Plug-ins Directory';
             $meta['description'] = 'Get the most recently updated plug-ins submitted to our directory of OpenRCT2 plug-ins';
             $nav['active'] = 'updated';
-            $list = getPluginList($p, 8, 'updated');
+            $list = getPluginList($p, $resultsPerPage, 'updated');
             $list['info']['title'] = "Recently updated plug-ins";
             break;
         case 'new':
         default:
             $nav['active'] = 'new';
-            $list = getPluginList($p);
+            $list = getPluginList($p, $resultsPerPage);
             $list['info']['title'] = "Newest plug-ins";
             break;
     }
 
+}
+
+// if the user requested the info as JSON
+if (isset($_GET['json'])) {
+    header('Content-Type: application/json');
+    $json = json_encode($list);
+    echo $json;
+    die;
 }
 
 // loads view

--- a/code/features/plugin/plugin.php
+++ b/code/features/plugin/plugin.php
@@ -3,6 +3,14 @@
 // gets plugin info
 $plugin = getPluginDetails($_GET['q2']);
 
+// if the user requested the info as JSON
+if (isset($_GET['json'])) {
+    header('Content-Type: application/json');
+    $json = json_encode($plugin);
+    echo $json;
+    die;
+}
+
 if (empty($plugin['id'])) {
     include("views/home/404.php");
     exit;

--- a/code/features/user/user.php
+++ b/code/features/user/user.php
@@ -9,8 +9,14 @@ if (empty($user['username'])) {
     exit;
 }
 
+// number of list items per page, limited to 100
+$resultsPerPage = isset($_GET['results']) ? intval($_GET['results']) : 8;
+if ($resultsPerPage > 100) {
+    $resultsPerPage = 100;
+}
+
 // gets list of plugins from database
-$list = getPluginList($p, 8, 'new', 'desc', $_GET['q2']);
+$list = getPluginList($p, $resultsPerPage, 'new', 'desc', $_GET['q2']);
 
 
 // set meta information
@@ -19,5 +25,14 @@ $meta['description'] = 'OpenRCT2 plugins by ' . $user['username'];
 $meta['url'] = $_SERVER['REQUEST_SCHEME'] . '://' . $_ENV['DOMAIN_NAME'] . '/user/' . $user['id'] . '/' . urlencode($user['username']);
 
 $list['info']['title'] = $user['username'] . "'s plug-ins";
+
+// if the user requested the info as JSON
+if (isset($_GET['json'])) {
+    header('Content-Type: application/json');
+    $json = json_encode($list);
+    echo $json;
+    die;
+}
+
 // loads view
 include_once("views/user/user.php");

--- a/code/index.php
+++ b/code/index.php
@@ -42,6 +42,10 @@ switch ($_GET['q1']) {
         require_once("./features/plugin/plugin.php");
         break;
 
+    case 'api':
+        require_once("./features/api/api.php");
+        break;
+
     case 'home':
     default:
 

--- a/code/lib/view_functions.php
+++ b/code/lib/view_functions.php
@@ -85,10 +85,30 @@ function drawPagination($curr_page = 1, $total_pages, $query = [], $compact = fa
     <?php
 }
 
-function drawList($list, $title = 'List', $usePagination = true, $viewMore = '', $curr_page='1') {
+function drawList($list, $title = 'List', $usePagination = true, $viewMore = '', $curr_page='1', $show_results_select = true, $results_select_value = 8) {
     ?>
     <div class="col-12 list-container">
-        <h2><?= $title ?></h2>
+        <div class="row align-items-center">
+            <div class="col">
+                <h2><?= $title ?></h2>
+            </div>
+            <?php if($show_results_select) { ?>
+            <div class="col-12 col-md-auto">
+                Results per page: 
+                <select name="results" id="results-select">
+                    <?php if(isset($_GET['results'])) { ?>
+                    <option value="<?= intval($_GET['results']) ?>"><?= intval($_GET['results']) ?></option>
+                    <option value="" disabled>___</option>
+                    <?php } ?>
+                    <option value="8">8</option>
+                    <option value="10">10</option>
+                    <option value="20">20</option>
+                    <option value="50">50</option>
+                    <option value="100">100</option>
+                </select>
+            </div>
+            <?php } ?>
+        </div>
         <div class="plugin-list">
             <?php
             // if for some reason the list is empty (mysql error, or empty seach), we show a feedback message, instead of an error

--- a/code/public/js/orct2p.js
+++ b/code/public/js/orct2p.js
@@ -43,3 +43,10 @@ document.querySelector('#submit-form').addEventListener('submit', function (e) {
         });
 
 });
+
+// whenever the user changes the "results per page dropdown"
+document.querySelector(`[name="results"]`).onchange = function(){
+    let url = new URL(window.location.href);
+    url.searchParams.set('results', this.value);
+    window.location.href = url.toString();
+};

--- a/code/views/home/home.php
+++ b/code/views/home/home.php
@@ -14,8 +14,8 @@
 
         <div class="row">
             <?php
-                drawList($list_new, 'Newest plug-ins', false, 'new');
-                drawList($list_rating, 'Most starred plug-ins', false, 'rating');
+                drawList($list_new, 'Newest plug-ins', false, 'new', 1, false);
+                drawList($list_rating, 'Most starred plug-ins', false, 'rating', 1, false);
             ?>
         </div>
 


### PR DESCRIPTION
This PR adds API support for most of the pages on the website.

you can now add a query string `json=true` to almost any page, and it will return the results in JSON.  
This works all the lists, as well as individual plugin pages and user pages.

It will also work with any type of sorting, new, rating, updated, and also for searches.

This PR also adds support to change the number of results per page (limited to max 100 results per page)

Examples:
List of plugins (second page, showing 20 results per page):  
`/list/?sort=new&results=20&p=2`

List of plugins by sadret:  
`/user/MDQ6VXNlcjE1ODk1NTMy?json=true`

Individual plugin:  
`/plugin/R_kgDOL_w7NA?json=true`
